### PR TITLE
DP-32: Added the apigee_edge_teams module also dependency.

### DIFF
--- a/sm_appdashboard_apigee.info.yml
+++ b/sm_appdashboard_apigee.info.yml
@@ -8,3 +8,4 @@ core: '8.x'
 core_version_requirement: ^8 || ^9
 dependencies:
   - apigee_edge:apigee_edge
+  - apigee_edge_teams:apigee_edge_teams


### PR DESCRIPTION
DP-32: Added the apigee_edge_teams module also dependency because we are using teams developer  service as dependency injection.